### PR TITLE
Implementation of HMZK (Mi Band 2) Font Format import and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The input format is determined by the file extension of the input file. Supporte
   *  `.fzx` - FZX by Andrew Owen (for ZX Spectrum)
   *  `.dsf` - DOSStart! by Daniel L. Nice
   *  `.sbf` - Sabriel Bitmap Font
+  *  `.hmzk` - [Mi Band 2 Font Format](https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-%28HMZK%29-Font-Format)
 
 On Mac OS X you can also launch or drop a font file onto the Bits'N'Picas application.
 
@@ -47,6 +48,7 @@ The input format is determined by the file extension of the input file. Supporte
   *  `.fzx` - FZX by Andrew Owen (for ZX Spectrum)
   *  `.dsf` - DOSStart! by Daniel L. Nice
   *  `.sbf` - Sabriel Bitmap Font
+  *  `.hmzk` - [Mi Band 2 Font Format](https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-%28HMZK%29-Font-Format)
 
 The output format is determined by the `-f` option. Supported output formats include:
   *  `kbits` or `kbnp` - Bits'N'Picas native save format
@@ -58,6 +60,7 @@ The output format is determined by the `-f` option. Supported output formats inc
   *  `rfont` - RFont, Kreative Software's extension of SFont
   *  `fzx` - FZX by Andrew Owen (for ZX Spectrum)
   *  `sbf` - Sabriel Bitmap Font
+  *  `hmzk` - [Mi Band 2 Font Format](https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-%28HMZK%29-Font-Format)
 
 Additional options include:
   *  `-s` *regex* `-r` *replacement* - Perform a search-and-replace on the font name.

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/BitmapExportPanel.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/BitmapExportPanel.java
@@ -32,6 +32,7 @@ import com.kreative.bitsnpicas.exporter.SBFBitmapFontExporter;
 import com.kreative.bitsnpicas.exporter.SFontBitmapFontExporter;
 import com.kreative.bitsnpicas.exporter.TOSBitmapFontExporter;
 import com.kreative.bitsnpicas.exporter.TTFBitmapFontExporter;
+import com.kreative.bitsnpicas.exporter.HMZKBitmapFontExporter;
 
 public class BitmapExportPanel extends JPanel {
 	private static final long serialVersionUID = 1L;
@@ -292,7 +293,12 @@ public class BitmapExportPanel extends JPanel {
 			public BitmapFontExporter createExporter(BitmapExportPanel bep) {
 				return new TOSBitmapFontExporter();
 			}
-		};
+        },
+        HMZK("HMZK (Mi Band 2)", ".hmzk", "none") {
+            public BitmapFontExporter createExporter(BitmapExportPanel bep) {
+                return new HMZKBitmapFontExporter();
+            }
+        };
 		
 		public final String name;
 		public final String suffix;

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/Main.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/Main.java
@@ -29,6 +29,7 @@ import com.kreative.bitsnpicas.importer.S10BitmapFontImporter;
 import com.kreative.bitsnpicas.importer.SBFBitmapFontImporter;
 import com.kreative.bitsnpicas.importer.SFDBitmapFontImporter;
 import com.kreative.bitsnpicas.importer.SRFontBitmapFontImporter;
+import com.kreative.bitsnpicas.importer.HMZKBitmapFontImporter;
 
 public class Main {
 	public static void main(String[] args) {
@@ -298,7 +299,10 @@ public class Main {
 		},
 		S10(".s10") {
 			public FontImporter<?> createImporter() { return new S10BitmapFontImporter(); }
-		};
+		},
+        HMZK(".hmzk") {
+            public FontImporter<?> createImporter() { return new HMZKBitmapFontImporter(); }
+        };
 		
 		public final String[] extensions;
 		public final boolean macResFork;

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/HMZKBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/HMZKBitmapFontExporter.java
@@ -1,0 +1,99 @@
+package com.kreative.bitsnpicas.exporter;
+
+import java.io.*;
+import java.util.Iterator;
+import java.util.Map;
+import com.kreative.bitsnpicas.BitmapFont;
+import com.kreative.bitsnpicas.BitmapFontExporter;
+import com.kreative.bitsnpicas.BitmapFontGlyph;
+
+/**
+ * HMZK is the bitmap font format used for the Mi Band 2.
+ * <a href="https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-%28HMZK%29-Font-Format" target="_blank">Reference</a>
+ */
+public class HMZKBitmapFontExporter implements BitmapFontExporter {
+    @Override
+    public byte[] exportFontToBytes(BitmapFont font) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        exportFont(font, new DataOutputStream(out));
+        out.close();
+        return out.toByteArray();
+    }
+
+    @Override
+    public void exportFontToStream(BitmapFont font, OutputStream os) throws IOException {
+        exportFont(font, new DataOutputStream(os));
+    }
+
+    @Override
+    public void exportFontToFile(BitmapFont font, File file) throws IOException {
+        FileOutputStream out = new FileOutputStream(file);
+        exportFont(font, new DataOutputStream(out));
+        out.close();
+    }
+    
+    private void exportFont(BitmapFont font, DataOutputStream out) throws IOException {
+        int len = 0;
+        // header
+        out.writeInt(0x484d5a4b);
+        out.writeInt(0x01ffffff);
+        out.writeInt(0xff00ffff);
+        out.writeShort(0xffff);
+
+        ByteArrayOutputStream chbuf = new ByteArrayOutputStream();
+        ByteArrayOutputStream glbuf = new ByteArrayOutputStream();
+        // map should be implicitly sorted by char
+        Iterator<Map.Entry<Integer, BitmapFontGlyph>> fit = font.characterIterator();
+        while (fit.hasNext()) {
+            len++;
+            if (2 * len > 0x3874) {
+                System.out.println("Probably too many characters, not all were written to the file.");
+                break;
+            }
+            Map.Entry<Integer, BitmapFontGlyph> entry = fit.next();
+            int ch = entry.getKey();
+            BitmapFontGlyph glyph = entry.getValue();
+            int gx = glyph.getX();
+            int gy = glyph.getY();
+            chbuf.write((byte)(ch & 0xFF));
+            chbuf.write((byte)((ch & 0xFF00) >> 8));
+            // construct bitmap
+            byte[][] glarr = glyph.getGlyph();
+            int gytop = 16 - gy;
+            for (int y = 0; y < 16; y++) {
+                if(y < gytop || y - gytop >= glarr.length) {
+                    glbuf.write(0);
+                    glbuf.write(0);
+                    continue;
+                }
+                byte[] row = glarr[y - gytop];
+                byte b = 0;
+                if(gx < 8) {
+                    for (int x = 0; x < 8 && x < row.length; x++) {
+                        if(row[x] != 0) {
+                            b |= 1 << (7 - x - gx);
+                        }
+                    }
+                }
+                glbuf.write(b);
+                b = 0;
+                if(gx < 16) {
+                    for (int x = 8; x < 16 && x < row.length; x++) {
+                        if(row[x] != 0) {
+                            b |= 1 << (15 - x - gx);
+                        }
+                    }
+                }
+                glbuf.write(b);
+            }
+            int h = glarr.length;
+            int w = 0;
+            if (h > 0) {
+                w = glarr[0].length;
+            }
+        }
+        out.writeShort(Short.reverseBytes((short)(len * 2)));
+        chbuf.writeTo(out);
+        glbuf.writeTo(out);
+    }
+}

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/HMZKBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/HMZKBitmapFontExporter.java
@@ -3,6 +3,7 @@ package com.kreative.bitsnpicas.exporter;
 import java.io.*;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.TreeMap;
 import com.kreative.bitsnpicas.BitmapFont;
 import com.kreative.bitsnpicas.BitmapFontExporter;
 import com.kreative.bitsnpicas.BitmapFontGlyph;
@@ -37,13 +38,21 @@ public class HMZKBitmapFontExporter implements BitmapFontExporter {
         // header
         out.writeInt(0x484d5a4b);
         out.writeInt(0x01ffffff);
-        out.writeInt(0xff00ffff);
+        //out.writeInt(0xff00ffff); // it's like this in Mili_pro.ft.en
+        out.writeInt(0xffffffff); // and like this in Mili_pro.ft
         out.writeShort(0xffff);
 
         ByteArrayOutputStream chbuf = new ByteArrayOutputStream();
         ByteArrayOutputStream glbuf = new ByteArrayOutputStream();
-        // map should be implicitly sorted by char
         Iterator<Map.Entry<Integer, BitmapFontGlyph>> fit = font.characterIterator();
+        // HashMap is not totally sorted, so we build a TreeMap from it
+        // There are probably more efficient ways to do this, but it's only for export anyway
+        TreeMap<Integer, BitmapFontGlyph> charmap = new TreeMap<>();
+        while (fit.hasNext()) {
+            Map.Entry<Integer, BitmapFontGlyph> entry = fit.next();
+            charmap.put(entry.getKey(), entry.getValue());
+        }
+        fit = charmap.entrySet().iterator();
         while (fit.hasNext()) {
             len++;
             if (2 * len > 0x3874) {

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/HMZKBitmapFontImporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/HMZKBitmapFontImporter.java
@@ -1,0 +1,63 @@
+package com.kreative.bitsnpicas.importer;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import com.kreative.bitsnpicas.BitmapFont;
+import com.kreative.bitsnpicas.BitmapFontGlyph;
+import com.kreative.bitsnpicas.BitmapFontImporter;
+
+/**
+ * HMZK is the monochrome bitmap font format used for the Mi Band 2
+ * <a href="https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-%28HMZK%29-Font-Format" target="_blank">Reference</a>
+ */
+public class HMZKBitmapFontImporter implements BitmapFontImporter {
+    public BitmapFont[] importFont(byte[] b) {
+        BitmapFont bm = new BitmapFont(16, 0, 16, 0, 0, 0);
+        // skip magic and padding
+        // FIXME: check magic number/charsLen and throw exceptions
+        int offset = 14;
+        int charsLen = ((b[offset + 1] & 0xFF) << 8) | (b[offset] & 0xFF);
+        int cellCount = charsLen / 2;
+        int charOff = offset + 2;
+        int bitmOff = charOff + charsLen;
+        for (int i = 0; i < cellCount; i++, charOff += 2, bitmOff += 32) {
+            byte[][] gd = new byte[16][16];
+            for (int yo = bitmOff, y = 0; y < 16; y++, yo += 2) {
+                for (int j = 0; j < 8; j++) {
+                    gd[y][7 - j] = (byte)(((b[yo] >> j) & 1) * 0xFF);
+                    gd[y][15 - j] = (byte)(((b[yo + 1] >> j) & 1) * 0xFF);
+                }
+            }
+            BitmapFontGlyph glyph = new BitmapFontGlyph(gd, 0, 16, 16);
+            int ch = ((b[charOff + 1] & 0xFF) << 8) | (b[charOff] & 0xFF);
+            bm.putCharacter(ch, glyph);
+
+        }
+        bm.setXHeight(16);
+        return new BitmapFont[]{bm};
+    }
+
+	public BitmapFont[] importFont(InputStream in) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] buf = new byte[1048576]; int read;
+		while ((read = in.read(buf)) >= 0) out.write(buf, 0, read);
+		out.close();
+		return importFont(out.toByteArray());
+	}
+	
+	public BitmapFont[] importFont(File file) throws IOException {
+		FileInputStream in = new FileInputStream(file);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] buf = new byte[1048576]; int read;
+		while ((read = in.read(buf)) >= 0) out.write(buf, 0, read);
+		out.close();
+		in.close();
+		return importFont(out.toByteArray());
+	}
+}

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/main/ConvertBitmap.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/main/ConvertBitmap.java
@@ -412,6 +412,11 @@ public class ConvertBitmap {
 			public BitmapFontExporter createExporter(Options o) {
 				return new TOSBitmapFontExporter();
 			}
+		},
+		HMZK(".hmzk", "hmzk", "hmzk") {
+			public BitmapFontExporter createExporter(Options o) {
+				return new HMZKBitmapFontExporter();
+			}
 		};
 		
 		public final String[] ids;


### PR DESCRIPTION
The [HMZK format](https://github.com/Freeyourgadget/Gadgetbridge/wiki/Mi-Band-2-(HMZK)-Font-Format) is a flashable bitmap font format for text notifications on the smartband Mi Band 2. It supports only 16x16 monochrome glyphs for 16 bit characters in Little-Endian UTF-16 that are listed in a map at the beginning of the file.