### PR TITLE
Prepend FOUNDRY field to XLFD generated for BDF export

### DIFF
--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/BDFBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/BDFBitmapFontExporter.java
@@ -78,7 +78,7 @@ public class BDFBitmapFontExporter implements BitmapFontExporter {
 		props.put("CAP_HEIGHT", Integer.toString(font.getCapHeight()));
 		
 		pw.println("STARTFONT 2.1");
-		pw.println("FONT -" + font.getName(Font.NAME_FAMILY) + "-" + font.getName(Font.NAME_STYLE) + "-" + (font.isItalicStyle() ? "I" : "R") + "-" + font.getName(Font.NAME_STYLE) + "--" + (font.getLineAscent() + font.getLineDescent()) + "-" + (font.getLineAscent() + font.getLineDescent()) + "-75-75-c-80-iso10646-1");
+		pw.println("FONT -" + font.getName(Font.NAME_MANUFACTURER) + "-" + font.getName(Font.NAME_FAMILY) + "-" + font.getName(Font.NAME_STYLE) + "-" + (font.isItalicStyle() ? "I" : "R") + "-" + font.getName(Font.NAME_STYLE) + "--" + (font.getLineAscent() + font.getLineDescent()) + "-" + (font.getLineAscent() + font.getLineDescent()) + "-75-75-c-80-iso10646-1");
 		pw.println("SIZE " + (font.getLineAscent() + font.getLineDescent()) + " 75 75");
 		pw.println("FONTBOUNDINGBOX " + (bbr-bbl) + " " + (bbt+bbb) + " " + bbl + " " + (-bbb));
 		pw.println("STARTPROPERTIES " + props.size());


### PR DESCRIPTION
A rather small change to fix something that was breaking some of my font generation pipelines. XLFD's should have 14 entries, but the XLFD generated by Bits'n'Picas only has 13 (missing the FOUNDRY field).