### PR TITLE
Implement Handling of Named Glyphs during BDF Import/Export

### DIFF
--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/BDFBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/BDFBitmapFontExporter.java
@@ -92,33 +92,40 @@ public class BDFBitmapFontExporter implements BitmapFontExporter {
 				BitmapFontGlyph g = font.getCharacter(i);
 				String h = Integer.toHexString(i).toUpperCase();
 				while (h.length() < 4) h = "0" + h;
-				pw.println("STARTCHAR U+" + h);
-				pw.println("ENCODING " + i);
-				pw.println("SWIDTH " + (1000 * g.getCharacterWidth() / (bbr-bbl)) + " 0");
-				pw.println("DWIDTH " + g.getCharacterWidth() + " 0");
-				pw.println("BBX " + g.getGlyphWidth() + " " + g.getGlyphHeight() + " " + g.getGlyphOffset() + " " + (-g.getGlyphDescent()));
-				pw.println("BITMAP");
-				for (byte[] row : g.getGlyph()) {
-					StringBuffer s = new StringBuffer();
-					for (int col = 0; col < row.length; col += 8) {
-						int b = 0;
-						for (int c = 0; c < 8; c++) {
-							b <<= 1;
-							if (col+c < row.length && row[col+c] < 0) {
-								b |= 1;
-							}
-						}
-						String bh = "00" + Integer.toHexString(b).toUpperCase();
-						bh = bh.substring(bh.length() - 2);
-						s.append(bh);
-					}
-					if (s.length() == 0) s.append("00");
-					pw.println(s.toString());
-				}
-				pw.println("ENDCHAR");
+				writeChar(pw, g, "U+" + h, i, bbl, bbr);
 			}
 		}
+		for (String name : font.namedGlyphs(false).keySet()) {
+			writeChar(pw, font.getNamedGlyph(name), name, -1, bbl, bbr);
+		}
 		pw.println("ENDFONT");
+	}
+	
+	private void writeChar(PrintWriter pw, BitmapFontGlyph g, String name, int i, int bbl, int bbr) {
+		pw.println("STARTCHAR " + name);
+		pw.println("ENCODING " + i);
+		pw.println("SWIDTH " + (1000 * g.getCharacterWidth() / (bbr-bbl)) + " 0");
+		pw.println("DWIDTH " + g.getCharacterWidth() + " 0");
+		pw.println("BBX " + g.getGlyphWidth() + " " + g.getGlyphHeight() + " " + g.getGlyphOffset() + " " + (-g.getGlyphDescent()));
+		pw.println("BITMAP");
+		for (byte[] row : g.getGlyph()) {
+			StringBuffer s = new StringBuffer();
+			for (int col = 0; col < row.length; col += 8) {
+				int b = 0;
+				for (int c = 0; c < 8; c++) {
+					b <<= 1;
+					if (col+c < row.length && row[col+c] < 0) {
+						b |= 1;
+					}
+				}
+				String bh = "00" + Integer.toHexString(b).toUpperCase();
+				bh = bh.substring(bh.length() - 2);
+				s.append(bh);
+			}
+			if (s.length() == 0) s.append("00");
+			pw.println(s.toString());
+		}
+		pw.println("ENDCHAR");
 	}
 	
 	private static String enquote(String s) {

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/BDFBitmapFontImporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/BDFBitmapFontImporter.java
@@ -50,7 +50,7 @@ public class BDFBitmapFontImporter implements BitmapFontImporter {
 		Charset cs = null;
 		while (scan.hasNextLine()) {
 			String[] kv = scan.nextLine().trim().split("\\s+", 2);
-			if (kv[0].equals("STARTCHAR")) readChar(scan, bm, cs);
+			if (kv[0].equals("STARTCHAR")) readChar(scan, bm, cs, kv[1]);
 			else if (kv[0].equals("ENDFONT")) break;
 			else if (kv.length < 2) continue;
 			else if (kv[0].equals("FAMILY_NAME")) bm.setName(Font.NAME_FAMILY, dequote(kv[1]));
@@ -109,7 +109,7 @@ public class BDFBitmapFontImporter implements BitmapFontImporter {
 		return bm;
 	}
 	
-	private void readChar(Scanner scan, BitmapFont bm, Charset cs) throws IOException {
+	private void readChar(Scanner scan, BitmapFont bm, Charset cs, String gn) throws IOException {
 		BitmapFontGlyph g = new BitmapFontGlyph();
 		int encoding = -1;
 		while (scan.hasNextLine()) {
@@ -154,6 +154,7 @@ public class BDFBitmapFontImporter implements BitmapFontImporter {
 			}
 		}
 		if (encoding >= 0) bm.putCharacter(encoding, g);
+    else bm.putNamedGlyph(gn, g);
 	}
 	
 	private boolean readBitmap(Scanner scan, BitmapFontGlyph g) {

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/BDFBitmapFontImporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/importer/BDFBitmapFontImporter.java
@@ -154,7 +154,7 @@ public class BDFBitmapFontImporter implements BitmapFontImporter {
 			}
 		}
 		if (encoding >= 0) bm.putCharacter(encoding, g);
-    else bm.putNamedGlyph(gn, g);
+		else bm.putNamedGlyph(gn, g);
 	}
 	
 	private boolean readBitmap(Scanner scan, BitmapFontGlyph g) {


### PR DESCRIPTION
Closes #61.

Basic behavior is to treat chars with ENCODING < 0 (i.e. -1) as named glyphs. Export will set ENCODING to -1.