### PR TITLE
Improve support for SOURCE_DATE_EPOCH by forcing UTC timezone; fix TrueType epoch timezone

### DIFF
--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/Font.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/Font.java
@@ -450,6 +450,7 @@ public abstract class Font<T extends FontGlyph> {
 			if (sourceDateEpochEnv != null) {
 				long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 				now.setTimeInMillis(sourceDateEpoch * 1000L);
+				now.setTimeZone(TimeZone.getTimeZone("UTC"));
 			}
 			names.put(NAME_UNIQUE_ID, "BitsNPicas: " + pname + ": " + now.get(Calendar.YEAR));
 		}

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/TimestampGlyphGenerator.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/edit/TimestampGlyphGenerator.java
@@ -2,6 +2,7 @@ package com.kreative.bitsnpicas.edit;
 
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.TimeZone;
 import com.kreative.bitsnpicas.BitmapFontGlyph;
 import com.kreative.bitsnpicas.Font;
 
@@ -17,6 +18,7 @@ public class TimestampGlyphGenerator extends GlyphGenerator<BitmapFontGlyph> {
 		if (sourceDateEpochEnv != null) {
 			long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 			now.setTimeInMillis(sourceDateEpoch * 1000L);
+			now.setTimeZone(TimeZone.getTimeZone("UTC"));
 		}
 		
 		BitmapFontGlyph[] glyphs = getTimestampGlyphs(font, now);

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/OTBBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/OTBBitmapFontExporter.java
@@ -12,6 +12,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import com.kreative.bitsnpicas.BitmapFont;
 import com.kreative.bitsnpicas.BitmapFontExporter;
 import com.kreative.bitsnpicas.BitmapFontGlyph;
@@ -256,6 +257,7 @@ public class OTBBitmapFontExporter implements BitmapFontExporter {
 		if (sourceDateEpochEnv != null) {
 			long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 			now.setTimeInMillis(sourceDateEpoch * 1000L);
+			now.setTimeZone(TimeZone.getTimeZone("UTC"));
 		}
 		
 		double fontVersion;

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/TTFBitmapFontExporter.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/exporter/TTFBitmapFontExporter.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import com.kreative.bitsnpicas.BitmapFont;
 import com.kreative.bitsnpicas.BitmapFontExporter;
 import com.kreative.bitsnpicas.BitmapFontGlyph;
@@ -234,6 +235,7 @@ public class TTFBitmapFontExporter implements BitmapFontExporter {
 		if (sourceDateEpochEnv != null) {
 			long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 			now.setTimeInMillis(sourceDateEpoch * 1000L);
+			now.setTimeZone(TimeZone.getTimeZone("UTC"));
 		}
 		
 		double fontVersion;

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/geos/CBMDirectoryBlock.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/geos/CBMDirectoryBlock.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 public class CBMDirectoryBlock implements CBMConstants {
 	public static final String COMMENT_PRG = "PRG formatted GEOS file";
@@ -53,6 +54,7 @@ public class CBMDirectoryBlock implements CBMConstants {
 		if (sourceDateEpochEnv != null) {
 			long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 			now.setTimeInMillis(sourceDateEpoch * 1000L);
+			now.setTimeZone(TimeZone.getTimeZone("UTC"));
 		}
 		
 		year = now.get(Calendar.YEAR);

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/main/ConvertBitmap.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/main/ConvertBitmap.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import com.kreative.bitsnpicas.BitmapFont;
@@ -582,6 +583,7 @@ public class ConvertBitmap {
 			if (sourceDateEpochEnv != null) {
 				long sourceDateEpoch = Long.parseLong(sourceDateEpochEnv);
 				now.setTimeInMillis(sourceDateEpoch * 1000L);
+				now.setTimeZone(TimeZone.getTimeZone("UTC"));
 			}
 			
 			BitmapFontGlyph[] glyphs = TimestampGlyphGenerator.getTimestampGlyphs(font, now);

--- a/main/java/BitsNPicas/src/com/kreative/bitsnpicas/truetype/HeadTable.java
+++ b/main/java/BitsNPicas/src/com/kreative/bitsnpicas/truetype/HeadTable.java
@@ -24,7 +24,7 @@ public class HeadTable extends TrueTypeTable {
 	public static final int FLAGS_DEFINED_BY_ADOBE_2                    = 0x1000;
 	public static final int FLAGS_DEFINED_BY_ADOBE_3                    = 0x2000;
 	public static final int FLAGS_GENERIC_SYMBOLS_FOR_CODE_POINT_RANGES = 0x4000;
-	public static final long DATE_EPOCH = new GregorianCalendar(1904, Calendar.JANUARY, 1, 0, 0, 0).getTimeInMillis();
+	public static final long DATE_EPOCH_1904 = 2082844800L * 1000L; // Milliseconds between 1904-01-01 00:00:00 UTC and Unix epoch
 	public static final int MAC_STYLE_PLAIN       = 0x00;
 	public static final int MAC_STYLE_BOLD        = 0x01;
 	public static final int MAC_STYLE_ITALIC      = 0x02;
@@ -81,23 +81,23 @@ public class HeadTable extends TrueTypeTable {
 	}
 	
 	public GregorianCalendar getDateCreatedCalendar() {
-		GregorianCalendar cal = new GregorianCalendar();
-		cal.setTimeInMillis(DATE_EPOCH + (dateCreated * 1000L));
+		GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		cal.setTimeInMillis((dateCreated * 1000L) - DATE_EPOCH_1904);
 		return cal;
 	}
 	
 	public void setDateCreatedCalendar(Calendar cal) {
-		dateCreated = (cal.getTimeInMillis() - DATE_EPOCH) / 1000L;
+		dateCreated = (cal.getTimeInMillis() + DATE_EPOCH_1904) / 1000L;
 	}
 	
 	public GregorianCalendar getDateModifiedCalendar() {
-		GregorianCalendar cal = new GregorianCalendar();
-		cal.setTimeInMillis(DATE_EPOCH + (dateModified * 1000L));
+		GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		cal.setTimeInMillis((dateModified * 1000L) - DATE_EPOCH_1904);
 		return cal;
 	}
 	
 	public void setDateModifiedCalendar(Calendar cal) {
-		dateModified = (cal.getTimeInMillis() - DATE_EPOCH) / 1000L;
+		dateModified = (cal.getTimeInMillis() + DATE_EPOCH_1904) / 1000L;
 	}
 	
 	@Override


### PR DESCRIPTION
The patch in PR #69 and its extension in commit 39936be did not address the reproducibility issues that arise when different timezones are used.

The Reproducible Builds project suggests forcing the use of the UTC timezone whenever `SOURCE_DATE_EPOCH` is used.

In order to be fully timezone-independent, the code that deals with the TrueType epoch must be fixed as well.

The TrueType epoch is supposed to be understood as an UTC date. Instantiating `GregorianCalendar` with a date implicitly sets its timezone to the local timezone.

Because it is not possible to pass both a date and a timezone to the constructor of `GregorianCalendar`, let's store the offset as a precalculated number (`date --date="1904-01-01 00:00:00 UTC" +%s`).

While we are at it, let's also switch from negative- to positive-offset calculations.

